### PR TITLE
Initial structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Maven
+target/
+
+# IntelliJ
+.idea/
+*.iml

--- a/LICENSE
+++ b/LICENSE
@@ -175,18 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 Simple Finance Technology Corp
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ public class MyApplication extends Application<MyConfiguration> {
 ```
 
 Metrics will be published with a prefix of
-`<metrics-prefix>.org.apache.common.metrics.MetricRegistry`
+`<metrics-prefix>.org.apache.kafka.common.metrics.MetricRegistry`
 where `metric-prefix` is the global prefix you've configured
 for your reporters.
 

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ public class MyApplication extends Application<MyConfiguration> {
 ```
 
 Metrics will be published with a prefix of
-`<metrics-prefix>.org.apache.kafka.common.metrics.MetricRegistry`
-where `metric-prefix` is the global prefix you've configured
-for your reporters.
+`<metrics-prefix>.org.apache.kafka.common.metrics`
+where `metric-prefix` is the global prefix
+you've configured for a given reporter.
 
 ## Configuration (Optional)
 
@@ -79,8 +79,10 @@ metric.dropwizard.registry=kafka-metrics
 
 To build the project, you'll need to
 [install Apache Maven 3](https://maven.apache.org/install.html).
-If you're on Mac OS X, installation via [Homebrew](http://brew.sh/)
-is recommended (`brew install maven`).
+If you're on Mac OS X, you can install Maven via [Homebrew](http://brew.sh/):
+
+    $ brew install maven
+
 Once that's installed, run the following from main directory
 (where `pom.xml` lives):
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
-# dropwizard-kafka-client-metrics
-Register your Kafka clients' built-in metrics to Dropwizard
+# kafka-dropwizard-reporter
+
+This package provides a `DropwizardReporter` class that connects the
+built-in metrics maintained by Kafka's client libraries with
+Dropwizard Metrics 3.0+.
+The Kafka metrics are added as `Gauge` instances to a Dropwizard
+`MetricRegistry` instance.
+
+If you're already using Dropwizard Metrics in your application
+to serve metrics via HTTP, Graphite, StatsD, etc.,
+this reporter provides an easy bridge to pass Kafka consumer,
+producer, and streams metrics to those same outputs.
+
+## Compatibility
+
+`dropwizard-metrics` 3.0 and above.
+
+`kafka-clients` 0.8.1 and above, including 0.9 and 0.10.
+Also functions with the new `kafka-streams` library in 0.10.0.0.
+
+## Usage
+
+First, declare a dependency on this package:
+```xml
+      <dependency>
+          <groupId>com.simple</groupId>
+          <artifactId>kafka-dropwizard-reporter</artifactId>
+          <version>1.0.0</version>
+      </dependency>
+```
+
+This package expects that `dropwizard-metrics` and `kafka-clients` libraries
+are also defined in your project.
+
+Then, include the `DropwizardReporter` class in the properties you pass
+to producers, consumers, and `KafkaStreams` applications:
+```
+metric.reporters=com.simple.metrics.kafka.DropwizardReporter
+```
+
+That client will now automatically register all of its built-in
+metrics with a Dropwizard `MetricRegistry` when it's initialized.
+
+## Integration with Dropwizard Applications
+
+The reporter calls `SharedMetricRegistries.getOrCreate("default")`
+to discover a registry. To make sure `DropwizardReporter` instances report
+to the main metrics registry of a Dropwizard application, call
+the following in your `run` method before defining any Kafka clients
+([this will be done by default in Dropwizard 1.0+](https://github.com/dropwizard/dropwizard/pull/1513)):
+```java
+public class MyApplication extends Application<MyConfiguration> {
+// [...]
+    @Override
+    public void run(MyConfiguration configuration, environment: Environment) {
+        SharedMetricRegistries.add("default", environment.metrics());
+    // [...]
+    }
+}
+```
+
+Metrics will be published with a prefix of
+`<metrics-prefix>.org.apache.common.metrics.MetricRegistry`
+where `metric-prefix` is the global prefix you've configured
+for your reporters.
+
+## Configuration (Optional)
+
+If you'd like to send Kafka metrics to a separate `MetricRegistry` instance,
+you can pass a name as `metric.dropwizard.registry` when configuring the client.
+For example, the following would end up calling
+`SharedMetricRegistries.getOrCreate("kafka-metrics")`:
+```
+metric.reporters=com.simple.metrics.kafka.DropwizardReporter
+metric.dropwizard.registry=kafka-metrics
+```
+
+## Building
+
+To build the project, you'll need to
+[install Apache Maven 3](https://maven.apache.org/install.html).
+If you're on Mac OS X, installation via [Homebrew](http://brew.sh/)
+is recommended (`brew install maven`).
+Once that's installed, run the following from main directory
+(where `pom.xml` lives):
+```
+mvn clean install
+```
+
+## Contributing
+
+Contributions, feature requests, and bug reports are all welcome.
+Feel free to [submit an issue](issues/new)
+or submit a pull request to this repo.
+
+## Also See
+
+This project takes significant inspiration from the `GraphiteReporter` class
+defined in [apakulov/kafka-graphite](https://github.com/apakulov/kafka-graphite).

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,33 @@
     <maven.compiler.target>1.7</maven.compiler.target>
   </properties>
 
-  <dependencies>
+  <developers>
+      <developer>
+          <name>Jeff Klukas</name>
+          <email>jeff@klukas.net</email>
+          <timezone>-5</timezone>
+      </developer>
+      <developer>
+          <name>Simple</name>
+          <email>support@simple.com</email>
+          <timezone>-8</timezone>
+      </developer>
+  </developers>
+
+    <licenses>
+        <license>
+            <url>http://www.apache.org/licenses/</url>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <issueManagement>
+        <system>github</system>
+        <url>http://github.com/SimpleFinance/kafka-dropwizard-reporter/issues#issue/</url>
+    </issueManagement>
+
+    <dependencies>
       <dependency>
           <groupId>io.dropwizard</groupId>
           <artifactId>dropwizard-metrics</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.simple</groupId>
+  <artifactId>kafka-dropwizard-reporter</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>kafka-dropwizard-reporter</name>
+  <url>https://github.com/SimpleFinance/kafka-dropwizard-reporter</url>
+  <description>Register built-in Kafka client metrics to Dropwizard Metrics</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+      <dependency>
+          <groupId>io.dropwizard</groupId>
+          <artifactId>dropwizard-metrics</artifactId>
+          <version>0.9.2</version>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+          <version>0.9.0.1</version>
+          <scope>provided</scope>
+      </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/main/java/com/simple/metrics/kafka/DropwizardReporter.java
+++ b/src/main/java/com/simple/metrics/kafka/DropwizardReporter.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 public class DropwizardReporter implements MetricsReporter {
     private static final Logger LOGGER = LoggerFactory.getLogger(DropwizardReporter.class);
+    private static final String METRIC_PREFIX = MetricsReporter.class.getPackage().getName();
 
     private MetricRegistry registry;
     private DropwizardReporterConfig config;
@@ -80,7 +81,7 @@ public class DropwizardReporter implements MetricsReporter {
         builder.setLength(builder.length() - 1);  // Remove the trailing dot.
         String processedName = builder.toString().replace(' ', '_').replace("\\.", "_");
 
-        return MetricRegistry.name(MetricsReporter.class, processedName);
+        return MetricRegistry.name(METRIC_PREFIX, processedName);
     }
 
 }

--- a/src/main/java/com/simple/metrics/kafka/DropwizardReporter.java
+++ b/src/main/java/com/simple/metrics/kafka/DropwizardReporter.java
@@ -1,0 +1,86 @@
+package com.simple.metrics.kafka;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class DropwizardReporter implements MetricsReporter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DropwizardReporter.class);
+
+    private MetricRegistry registry;
+    private DropwizardReporterConfig config;
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.config = new DropwizardReporterConfig(configs);
+    }
+
+    @Override
+    public void init(List<KafkaMetric> list) {
+        if (config == null) {
+            throw new IllegalStateException("Must call configure() before calling init() on a reporter.");
+        }
+        String registryName = config.getString(DropwizardReporterConfig.REGISTRY_PROPERTY_NAME);
+        this.registry = SharedMetricRegistries.getOrCreate(registryName);
+        for (KafkaMetric kafkaMetric : list) {
+            this.metricChange(kafkaMetric);
+        }
+    }
+
+    @Override
+    public void metricChange(final KafkaMetric kafkaMetric) {
+        LOGGER.debug("Processing a metric change for {}", kafkaMetric.metricName().toString());
+        String name = dropwizardMetricName(kafkaMetric);
+        Gauge<Double> gauge = new Gauge<Double>() {
+            @Override
+            public Double getValue() {
+                return kafkaMetric.value();
+            }
+        };
+        if (registry.getGauges().containsKey(name)) {
+            LOGGER.debug("{} was already registered, so first removing.", name);
+            registry.remove(name);
+        }
+        LOGGER.debug("Registering {}", name);
+        registry.register(name, gauge);
+    }
+
+    @Override
+    public void metricRemoval(KafkaMetric kafkaMetric) {
+        String name = dropwizardMetricName(kafkaMetric);
+        LOGGER.debug("Removing {}", name);
+        registry.remove(name);
+    }
+
+    @Override
+    public void close() {}
+
+    private String dropwizardMetricName(KafkaMetric kafkaMetric) {
+        MetricName name = kafkaMetric.metricName();
+
+        List<String> nameParts = new ArrayList<String>(2);
+        nameParts.add(name.group());
+        nameParts.addAll(name.tags().values());
+        nameParts.add(name.name());
+
+        StringBuilder builder = new StringBuilder();
+        for (String namePart : nameParts) {
+            builder.append(namePart);
+            builder.append(".");
+        }
+        builder.setLength(builder.length() - 1);  // Remove the trailing dot.
+        String processedName = builder.toString().replace(' ', '_').replace("\\.", "_");
+
+        return MetricRegistry.name(MetricsReporter.class, processedName);
+    }
+
+}

--- a/src/main/java/com/simple/metrics/kafka/DropwizardReporterConfig.java
+++ b/src/main/java/com/simple/metrics/kafka/DropwizardReporterConfig.java
@@ -1,0 +1,19 @@
+package com.simple.metrics.kafka;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Map;
+
+public class DropwizardReporterConfig extends AbstractConfig {
+    public static final String DEFAULT_REGISTRY_NAME = "default";
+    public static final String REGISTRY_PROPERTY_NAME = "metric.dropwizard.registry";
+
+    private static final ConfigDef configDefinition = new ConfigDef()
+            .define(REGISTRY_PROPERTY_NAME, ConfigDef.Type.STRING, DEFAULT_REGISTRY_NAME, ConfigDef.Importance.LOW,
+                    "Name of the dropwizard-metrics registry to use; passed to SharedMetricRegistries.getOrCreate");
+
+    DropwizardReporterConfig(Map<?, ?> props) {
+        super(configDefinition, props);
+    }
+}

--- a/src/test/java/com/simple/metrics/kafka/DropwizardReporterTest.java
+++ b/src/test/java/com/simple/metrics/kafka/DropwizardReporterTest.java
@@ -23,7 +23,7 @@ public class DropwizardReporterTest {
         sensor.add(new MetricName("pack.bean1.avg", "grp1"), new Avg());
 
         Map<String, Gauge> gauges = SharedMetricRegistries.getOrCreate("default").getGauges();
-        String expectedName = "org.apache.kafka.common.metrics.MetricsReporter.grp1.pack.bean1.avg";
+        String expectedName = "org.apache.kafka.common.metrics.grp1.pack.bean1.avg";
         Assert.assertEquals(1, gauges.size());
         Assert.assertEquals(expectedName, gauges.keySet().toArray()[0]);
 

--- a/src/test/java/com/simple/metrics/kafka/DropwizardReporterTest.java
+++ b/src/test/java/com/simple/metrics/kafka/DropwizardReporterTest.java
@@ -1,0 +1,35 @@
+package com.simple.metrics.kafka;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.SharedMetricRegistries;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DropwizardReporterTest {
+    @Test
+    public void testMetricChange() throws Exception {
+        Metrics metrics = new Metrics();
+        DropwizardReporter reporter = new DropwizardReporter();
+        reporter.configure(new HashMap<String, Object>());
+        metrics.addReporter(reporter);
+        Sensor sensor = metrics.sensor("kafka.requests");
+        sensor.add(new MetricName("pack.bean1.avg", "grp1"), new Avg());
+
+        Map<String, Gauge> gauges = SharedMetricRegistries.getOrCreate("default").getGauges();
+        String expectedName = "org.apache.kafka.common.metrics.MetricsReporter.grp1.pack.bean1.avg";
+        Assert.assertEquals(1, gauges.size());
+        Assert.assertEquals(expectedName, gauges.keySet().toArray()[0]);
+
+        sensor.record(2.1);
+        sensor.record(2.2);
+        sensor.record(2.6);
+        Assert.assertEquals(2.3, (Double)gauges.get(expectedName).getValue(), 0.001);
+    }
+}


### PR DESCRIPTION
We're currently using https://github.com/apakulov/kafka-graphite to send Kafka client metrics to Graphite, but that involves some hacky code to pull configuration out of the top-level `metrics` configuration of the application and duplicate it.

This project aims to provide more elegant integration with our Dropwizard services by registering Kafka client metrics to Dropwizard Metrics, thus using the same metrics pipeline as the rest of the application.

---

Once this is merged, I have some follow-up steps in mind:

- publish to Maven Central
- advertise to the Dropwizard community by submitting a PR to be included on http://modules.dropwizard.io/thirdparty/
- advertise to the Kafka community by asking to include a link on https://cwiki.apache.org/confluence/display/KAFKA/Ecosystem
- integrate into the Simple data team's `tricorder-kafka` library