### PR TITLE
Use metrics-core instead of dropwizard-metrics

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>com.simple</groupId>
             <artifactId>kafka-dropwizard-reporter</artifactId>
-            <version>1.0.0</version>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.dropwizard</groupId>
-            <artifactId>dropwizard-metrics</artifactId>
-            <version>0.9.2</version>
-            <scope>provided</scope>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -92,6 +91,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.21</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
There are no Dropwizard-specific classes being used in this project.

It only depends on the [Metrics](http://metrics.dropwizard.io/) library.