### PR TITLE
Skip change if metric already exists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
+                <version>2.10.4</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
There was a race condition here. If two threads tried to create the same metric close in time, the if exists check could indicate it doesn't exist, but then it's already been created. This version catches the exception instead of making an explicit existence check.